### PR TITLE
Fix for HUDSON-8519

### DIFF
--- a/src/main/java/hudson/plugins/bazaar/BazaarTagAction.java
+++ b/src/main/java/hudson/plugins/bazaar/BazaarTagAction.java
@@ -157,8 +157,10 @@ public class BazaarTagAction extends AbstractScmTagAction implements Describable
         @Override
         public void onChangeLogParsed(AbstractBuild<?,?> build, BuildListener listener, ChangeLogSet<?> changelog) throws Exception {
             for (Object changelogEntry : changelog) {
-                BazaarChangeSet changeset = (BazaarChangeSet) changelogEntry;
-                revisions.add(new BazaarRevision(changeset.getRevid(), changeset.getRevno(), changeset.getTags()));
+            	if (changelogEntry instanceof BazaarChangeSet) {
+            		BazaarChangeSet changeset = (BazaarChangeSet) changelogEntry;
+            		revisions.add(new BazaarRevision(changeset.getRevid(), changeset.getRevno(), changeset.getTags()));
+				}
             }
         }
     }


### PR DESCRIPTION
BazaarTagAction:160 had ClassCastExceptions on various occasions when both Bazaar and SVN plugins are used in the same Hudson environment and the job had incoming changes from SVN. (See: http://issues.hudson-ci.org/browse/HUDSON-8519)

Please kindly accept this fix and include it in the next plugin release - thanks!
