### PR TITLE
fix file descriptor leak which lead to jenkins being unable to start

### DIFF
--- a/src/main/java/hudson/plugins/bazaar/BazaarChangeLogParser.java
+++ b/src/main/java/hudson/plugins/bazaar/BazaarChangeLogParser.java
@@ -194,6 +194,7 @@ public class BazaarChangeLogParser extends ChangeLogParser {
         // Remove current revision entry
         entries = entries.subList(0, Math.max(0 ,entries.size() -1));
 
+        in.close();
         return new BazaarChangeSetList(build, entries);
     }
 


### PR DESCRIPTION
a really bad place where Jenkins would refuse to start (Too many files open)
if you had many jobs and garbage collection didn't kick in.
