### PR TITLE
Auto-recover on corrupted bzr repo

### DIFF
--- a/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
+++ b/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
@@ -281,6 +281,13 @@ public class BazaarSCM extends SCM implements Serializable {
         try {
             if (launcher.launch().cmds(args).envs(build.getEnvironment(listener)).stdout(listener.getLogger()).pwd(workspace).join() != 0) {
                 listener.error("Failed to " + verb);
+		try {
+		    listener.getLogger().println("Since BZR itself isn't crash safe, we'll clean the workspace so that on the next try we'll do a clean pull...");
+		    workspace.deleteRecursive();
+		} catch (IOException e) {
+		    e.printStackTrace(listener.error("Failed to clean the workspace"));
+		    return false;
+		}
                 return false;
             }
         } catch (IOException e) {


### PR DESCRIPTION
  On failing to branch a tree, assume that BZR has had a problem due
  to not being crash safe in all situations (e.g. cancelling a build during
  initial checkout) and wipe the tree and start again.

We've tested this pretty heavily at Percona and before this patch we pretty
much _had_ to have "clean workspace" enabled (or clean the workspace very,
very often). With this patch, we have not had to do so ever again.
