### PR TITLE
Issue when viewing the project configuration page, set options were not checked

### DIFF
--- a/src/main/resources/hudson/plugins/bazaar/BazaarSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/bazaar/BazaarSCM/config.jelly
@@ -5,10 +5,10 @@
   <t:listScmBrowsers name="bzr.browser" />
   <f:advanced>
     <f:entry title="${%Clean Tree}" help="/plugin/bazaar/clean.html">
-      <f:checkbox name="bzr.cleantree" checked="${instance.cleantree}" />
+      <f:checkbox name="bzr.cleantree" checked="${instance.isCleanTree()}" />
     </f:entry>
     <f:entry title="${%Lightweight Checkout}" help="/plugin/bazaar/checkout.html">
-      <f:checkbox name="bzr.checkout" checked="${instance.checkout}" />
+      <f:checkbox name="bzr.checkout" checked="${instance.isCheckout()}" />
     </f:entry>
   </f:advanced>
 </j:jelly>


### PR DESCRIPTION
config.jelly was trying to access the private boolean fields of
BazaarSCM directly, which resulted in in the checkboxes not being
populated when returning to the project configuration page.  Updated to
use the public accessor functions for checkout and cleantree with fixes
the issue.
