### PR TITLE
support multiscm usage by not injecting env variables

### DIFF
--- a/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
+++ b/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
@@ -457,7 +457,13 @@ public class BazaarSCM extends SCM implements Serializable {
 
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, Map<String, String> env) {
-        BazaarRevisionState revisionState = (BazaarRevisionState) build.getAction(SCMRevisionState.class);
+        SCMRevisionState scmRevisionState = build.getAction(SCMRevisionState.class);
+        if (!(scmRevisionState instanceof BazaarRevisionState)) {
+            // MultiSCM hijacks the RevisionState object. Also, with multiple bazaars it becomes increasingly less
+            // meaningful to inject environment variables.
+            return;
+        }
+        BazaarRevisionState revisionState = (BazaarRevisionState) scmRevisionState;
         if (revisionState != null) {
           if (revisionState.getRevNo() != null) {
             env.put("BZR_REVISION", revisionState.getRevNo());


### PR DESCRIPTION
MultiSCM hijacks the revisionstate and introduces a super-state aggregating all SCM's states, this subsequently fails to cast to a BazaarRevisionState.
