### PR TITLE
Null baseline

### DIFF
--- a/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
+++ b/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
@@ -240,14 +240,14 @@ public class BazaarSCM extends SCM implements Serializable {
         final Change change;
         output.printf("Baseline is %s.\n", baseline);
         if (remote == null) {
-	    output.printf("Failed to get current remote revision, assuming no change.\n");
-	    change = Change.NONE;
-	}
-	else if ((baseline == SCMRevisionState.NONE)
-            // appears that other instances of None occur - its not a singleton.
-            // so do a (fugly) class check.
-            || (baseline.getClass() != BazaarRevisionState.class)
-            || (!remote.equals(baseline)))
+            output.printf("Failed to get current remote revision, assuming no change.\n");
+            change = Change.NONE;
+        }
+        else if ((baseline == SCMRevisionState.NONE)
+                // appears that other instances of None occur - its not a singleton.
+                // so do a (fugly) class check.
+                || (baseline.getClass() != BazaarRevisionState.class)
+                || (!remote.equals(baseline)))
             change = Change.SIGNIFICANT;
         else
             change = Change.NONE;

--- a/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
+++ b/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
@@ -243,6 +243,8 @@ public class BazaarSCM extends SCM implements Serializable {
             output.printf("Failed to get current remote revision, assuming no change.\n");
             change = Change.NONE;
         } else if ((baseline == SCMRevisionState.NONE)
+                // If we can't qualify the base revision (i.e. previous run) always default to change.
+                || (baseline == null)
                 // appears that other instances of None occur - its not a singleton.
                 // so do a (fugly) class check.
                 || (baseline.getClass() != BazaarRevisionState.class)

--- a/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
+++ b/src/main/java/hudson/plugins/bazaar/BazaarSCM.java
@@ -242,15 +242,15 @@ public class BazaarSCM extends SCM implements Serializable {
         if (remote == null) {
             output.printf("Failed to get current remote revision, assuming no change.\n");
             change = Change.NONE;
-        }
-        else if ((baseline == SCMRevisionState.NONE)
+        } else if ((baseline == SCMRevisionState.NONE)
                 // appears that other instances of None occur - its not a singleton.
                 // so do a (fugly) class check.
                 || (baseline.getClass() != BazaarRevisionState.class)
-                || (!remote.equals(baseline)))
+                || (!remote.equals(baseline))) {
             change = Change.SIGNIFICANT;
-        else
+        } else{
             change = Change.NONE;
+        }
         return new PollingResult(baseline,remote,change);
     }
 


### PR DESCRIPTION
prevent a null baseline argument from raising an exception when we access the baseline object. simple nullness check.

I am not entirely confident as to why it is null to begin with, but given the api documentation I'd suppose any number of things can cause it and once it is null it's hard to poll your way out of it again given the poll consistently will fail on the raised exception.
By checking for nullness we may force runs when none are needed, OTOH when baseline is null we can't qualify whether or not it is needed anyway.